### PR TITLE
Fix logo max height

### DIFF
--- a/avElection/layouts/default-election-directive/default-election-directive.less
+++ b/avElection/layouts/default-election-directive/default-election-directive.less
@@ -32,7 +32,7 @@
   }
 
   .logo-img {
-    max-height: 150px;
+    max-height: 27px;
     max-width: 400px;
     width: auto;
   }


### PR DESCRIPTION
The css for the logo at the top left is too large, this fixes it.

Before
<img width="724" alt="Screenshot 2022-07-06 at 14 53 19" src="https://user-images.githubusercontent.com/3913223/177567425-f3610a33-0218-41a3-b5f9-abb0ee011f91.png">

Afte
<img width="675" alt="Screenshot 2022-07-06 at 14 53 34" src="https://user-images.githubusercontent.com/3913223/177567438-328e11d5-a3f3-45bd-88c4-14d18e43cfc2.png">
r