### PR TITLE
adding support for preventSiteTranslation

### DIFF
--- a/SequentConfig.js
+++ b/SequentConfig.js
@@ -62,6 +62,10 @@ var SequentConfigData = {
   // allowed values: true| false
   showDocOnVoteCast: false,
 
+  // Prevents site translation using the translation=on html attribute
+  // allowed values: true | false
+  preventSiteTranslation: false,
+
   resourceUrlWhitelist: [
     // Allow same origin resource loads.
     'self',

--- a/app.js
+++ b/app.js
@@ -61,7 +61,13 @@ angular.module('jm.i18next').config(function ($i18nextProvider, ConfigServicePro
       resGetPath: '/election/locales/__lng__.json',
       defaultLoadingValue: '' // ng-i18next option, *NOT* directly supported by i18next
     },
-    ConfigServiceProvider.i18nextInitOptions);
+    ConfigServiceProvider.i18nextInitOptions
+  );
+
+  // Prevent site translation if configured
+  if (ConfigServiceProvider.preventSiteTranslation) {
+    $('html').attr('translate', 'no');
+  }
 });
 
 angular.module('election-portal').config(function($sceDelegateProvider, ConfigServiceProvider) {


### PR DESCRIPTION
## Problem description

In some cases, the web browser automatically translates the frontend web sites when it shouldn't. EPI has reported this happening in a case in which the whole website is already in english, but the browser detects the german article `die` as an english word and translate it to the english translation of the word `die`. Not good.

## Proposed Solution

Add to `config.yml` a parameter `config.sequent_ui.prevent_site_translation` that is `false` by default, but when enabled it sets the `translate="no"` attribute to the `<html>` element . [`translate`is an official HTML5 attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/translate) that indicates that the content of this element should not be translated.

## Rationale

Adding the `translate="no"` attribute should prevent the browser from translating what it shouldn't. Note that, we are already indicating the language of the content in the HTML element, so it should not be translating from that language. And if the text language is for example "german" and the user wants a translation to "arabic", we would be preventing that from happening. For that reason, this should not be enabled by default. But in any specific deployment, it can be set.
