### PR TITLE
Fix ORT Github Workflow (#191)

### DIFF
--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -1,5 +1,5 @@
 
-# SPDX-FileCopyrightText: 2014-2022 Sequent Tech Inc <legal@sequentech.io>
+# SPDX-FileCopyrightText: 2014-2023 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 name: ORT licensing
@@ -18,9 +18,6 @@ on:
 
 jobs:
   ort:
-    uses: sequentech/ort-config/.github/workflows/ort.yml@main
+    uses: sequentech/meta/.github/workflows/ort.yml@main
     with:
-      ort-cli-args: > # using the default plus the package managers setting
-        --force-overwrite
-        --stacktrace
-        -P ort.analyzer.enabledPackageManagers=Yarn
+      ort-cli-analyze-args: '--package-managers Yarn'


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/59

Use the reusable workflow from the meta repository instead.